### PR TITLE
Rename XpmMiniStreamType to XpmStreamType and move it to XpmPkg

### DIFF
--- a/xpm/rtl/XpmApp.vhd
+++ b/xpm/rtl/XpmApp.vhd
@@ -75,7 +75,7 @@ entity XpmApp is
       timingClk       : in  sl;
       timingRst       : in  sl;
 --      timingIn          : in  TimingRxType;
-      timingStream    : in  XpmMiniStreamType;
+      timingStream    : in  XpmStreamType;
       timingFbClk     : in  sl;
       timingFbRst     : in  sl;
       timingFbId      : in  slv(31 downto 0);

--- a/xpm/rtl/XpmMini.vhd
+++ b/xpm/rtl/XpmMini.vhd
@@ -57,7 +57,7 @@ entity XpmMini is
       timingClk    : in  sl;
       timingRst    : in  sl;
       dsTx         : out TimingPhyArray (NUM_DS_LINKS_G-1 downto 0);
-      timingStream : in  XpmMiniStreamType);
+      timingStream : in  XpmStreamType);
 end XpmMini;
 
 architecture top_level_app of XpmMini is

--- a/xpm/rtl/XpmMiniPkg.vhd
+++ b/xpm/rtl/XpmMiniPkg.vhd
@@ -32,21 +32,6 @@ package XpmMiniPkg is
    -----------------------------------------------------------
    -- Application: Configurations, Constants and Records Types
    -----------------------------------------------------------
-
-   -- This doesn't belong here but not sure where to move it
-   constant NSTREAMS_C : integer := 3;
-
-   type XpmMiniStreamType is record
-      fiducial : sl;
-      streams  : TimingSerialArray(NSTREAMS_C-1 downto 0);
-      advance  : slv (NSTREAMS_C-1 downto 0);
-   end record;
-
-   constant XPM_MINI_STREAM_INIT_C : XpmMiniStreamType := (
-      fiducial => '0',
-      streams  => (others => TIMING_SERIAL_INIT_C),
-      advance  => (others => '0'));
-
    type XpmMiniPartitionStatusType is record
       l0Select : XpmL0SelectStatusType;
    end record;

--- a/xpm/rtl/XpmMiniWrapper.vhd
+++ b/xpm/rtl/XpmMiniWrapper.vhd
@@ -79,18 +79,18 @@ architecture top_level of XpmMiniWrapper is
 
    signal xpmStatus : XpmMiniStatusType;
    signal xpmConfig : XpmMiniConfigType;
-   signal xpmStream : XpmMiniStreamType := XPM_MINI_STREAM_INIT_C;
+   signal xpmStream : XpmStreamType := XPM_STREAM_INIT_C;
 
    signal update : sl;
 
    type RegType is record
-     advance : sl;
+      advance : sl;
    end record;
 
-   constant REG_INIT_C : RegType := ( advance => '0' );
+   constant REG_INIT_C : RegType := (advance => '0');
 
-   signal r    : RegType := REG_INIT_C;
-   signal rin  : RegType;
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
 
 begin
 
@@ -182,28 +182,28 @@ begin
          dsTx         => dsTx,
          timingStream => xpmStream);
 
-   comb : process ( r, timingRst, tpgFiducial, tpgStream ) is
-     variable v : RegType;
+   comb : process (r, timingRst, tpgFiducial, tpgStream) is
+      variable v : RegType;
    begin
-     v := r;
+      v := r;
 
-     v.advance := tpgStream.ready and not tpgFiducial;
-     
-     if timingRst = '1' then
-       v := REG_INIT_C;
-     end if;
+      v.advance := tpgStream.ready and not tpgFiducial;
 
-     rin <= v;
+      if timingRst = '1' then
+         v := REG_INIT_C;
+      end if;
 
-     tpgAdvance <= v.advance;
+      rin <= v;
+
+      tpgAdvance <= v.advance;
    end process;
 
-   seq : process ( timingClk )
+   seq : process (timingClk)
    begin
-     if rising_edge(timingClk) then
-       r <= rin;
-     end if;
+      if rising_edge(timingClk) then
+         r <= rin;
+      end if;
    end process;
-   
+
 end top_level;
 

--- a/xpm/rtl/XpmPkg.vhd
+++ b/xpm/rtl/XpmPkg.vhd
@@ -21,6 +21,9 @@ use ieee.std_logic_arith.all;
 library surf;
 use surf.StdRtlPkg.all;
 
+library lcls_timing_core;
+use lcls_timing_core.TimingPkg.all;
+
 package XpmPkg is
 
    -----------------------------------------------------------
@@ -37,6 +40,20 @@ package XpmPkg is
    constant XPM_NUM_TAG_BYTES_C   : integer := 4;
    constant XPM_NUM_L1_TRIGGERS_C : integer := 1;
    constant XPM_LCTR_DEPTH_C      : integer := 40;
+
+   -- This doesn't belong here but not sure where to move it
+   constant NSTREAMS_C : integer := 3;
+
+   type XpmStreamType is record
+      fiducial : sl;
+      streams  : TimingSerialArray(NSTREAMS_C-1 downto 0);
+      advance  : slv (NSTREAMS_C-1 downto 0);
+   end record;
+
+   constant XPM_STREAM_INIT_C : XpmStreamType := (
+      fiducial => '0',
+      streams  => (others => TIMING_SERIAL_INIT_C),
+      advance  => (others => '0'));
 
    type XpmTxSerialType is record
       data  : slv(15 downto 0);


### PR DESCRIPTION
This record was misnamed and misplaced before, as it was not exclusive to XpmMini.