### PR TITLE
Update submodule locks

### DIFF
--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -8,9 +8,9 @@ if { [VersionCheck 2016.4 ] < 0 } {
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
-   if { [SubmoduleCheck {ruckus}           {2.0.4}  ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}             {2.0.4}  ] < 0 } {exit -1}
-   if { [SubmoduleCheck {lcls-timing-core} {3.0.0}  ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus}           {2.1.2}  ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}             {2.0.6}  ] < 0 } {exit -1}
+   if { [SubmoduleCheck {lcls-timing-core} {3.0.1}  ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
Use the latest ruckus, surf and lcls-timing-core releases.