### PR TITLE
Fix method with missing self param

### DIFF
--- a/python/l2si_core/_TriggerEventBuffer.py
+++ b/python/l2si_core/_TriggerEventBuffer.py
@@ -213,5 +213,5 @@ class TriggerEventBuffer(pr.Device):
             bitOffset = 0,
             function = pr.RemoteCommand.touchOne))
         
-    def countReset():
+    def countReset(self):
         self.ResetCounters()


### PR DESCRIPTION
Fix `countReset()` method with missing `self` param.