### PR TITLE
Pass clearReadout signal up for use by application

### DIFF
--- a/base/rtl/TriggerEventBuffer.vhd
+++ b/base/rtl/TriggerEventBuffer.vhd
@@ -266,7 +266,7 @@ begin
 
          -- Special case - reset fifo, mask any tValid
          -- Note that this logic is active even when the r.enable register = 0.
-         if (v.transitionData.valid = '1' and v.transitionData.header = MSG_CLEARREADOUT_FIFO_C) then
+         if (v.transitionData.valid = '1' and v.transitionData.header = MSG_CLEAR_FIFO_C) then
             v.overflow              := '0';
             v.fifoRst               := '1';
             v.fifoAxisMaster.tValid := '0';

--- a/base/rtl/TriggerEventBuffer.vhd
+++ b/base/rtl/TriggerEventBuffer.vhd
@@ -66,7 +66,7 @@ entity TriggerEventBuffer is
       triggerClk  : in  sl;
       triggerRst  : in  sl;
       triggerData : out TriggerEventDataType;
-      clear       : out sl;
+
 
       -- Event/Transition output
       eventClk           : in  sl;
@@ -74,7 +74,8 @@ entity TriggerEventBuffer is
       eventTimingMessage : out TimingMessageType;
       eventAxisMaster    : out AxiStreamMasterType;
       eventAxisSlave     : in  AxiStreamSlaveType;
-      eventAxisCtrl      : in  AxiStreamCtrlType);
+      eventAxisCtrl      : in  AxiStreamCtrlType;
+      clearReadout       : out sl);
 
 end entity TriggerEventBuffer;
 
@@ -265,7 +266,7 @@ begin
 
          -- Special case - reset fifo, mask any tValid
          -- Note that this logic is active even when the r.enable register = 0.
-         if (v.transitionData.valid = '1' and v.transitionData.header = MSG_CLEAR_FIFO_C) then
+         if (v.transitionData.valid = '1' and v.transitionData.header = MSG_CLEARREADOUT_FIFO_C) then
             v.overflow              := '0';
             v.fifoRst               := '1';
             v.fifoAxisMaster.tValid := '0';
@@ -427,13 +428,13 @@ begin
             dout   => syncTriggerDataSlv);      -- [out]
       triggerData <= toXpmEventDataType(syncTriggerDataSlv, syncTriggerDataValid);
 
-      U_SynchronizerClear : entity surf.Synchronizer
+      U_SynchronizerClearReadout : entity surf.SynchronizerOneShot
          generic map (
             TPD_G => TPD_G)
          port map (
-            clk     => triggerClk,
+            clk     => eventClk,
             dataIn  => r.fifoRst,
-            dataOut => clear);
+            dataOut => clearReadout);
    end generate TRIGGER_SYNC_GEN;
 
    NO_TRIGGER_SYNC_GEN : if (TRIGGER_CLK_IS_TIMING_RX_CLK_G) generate

--- a/base/rtl/TriggerEventManager.vhd
+++ b/base/rtl/TriggerEventManager.vhd
@@ -62,7 +62,6 @@ entity TriggerEventManager is
       triggerClk  : in  sl;
       triggerRst  : in  sl;
       triggerData : out TriggerEventDataArray(NUM_DETECTORS_G-1 downto 0);
-      clear       : out slv(NUM_DETECTORS_G-1 downto 0);
 
       -- L1 trigger feedback
       l1Clk       : in  sl                                                 := '0';
@@ -77,6 +76,7 @@ entity TriggerEventManager is
       eventAxisMasters    : out AxiStreamMasterArray(NUM_DETECTORS_G-1 downto 0);
       eventAxisSlaves     : in  AxiStreamSlaveArray(NUM_DETECTORS_G-1 downto 0);
       eventAxisCtrl       : in  AxiStreamCtrlArray(NUM_DETECTORS_G-1 downto 0);
+      clearReadout        : out slv(NUM_DETECTORS_G-1 downto 0);
 
       -- AXI-Lite
       axilClk         : in  sl;
@@ -293,13 +293,13 @@ begin
             triggerClk           => triggerClk,                          -- [in]
             triggerRst           => triggerRst,                          -- [in]
             triggerData          => triggerData(i),                      -- [out]
-            clear                => clear(i),                            -- [out]
             eventClk             => eventClk,                            -- [in]
             eventRst             => eventRst,                            -- [in]
             eventTimingMessage   => eventTimingMessages(i),              -- [out]
             eventAxisMaster      => eventAxisMasters(i),                 -- [out]
             eventAxisSlave       => eventAxisSlaves(i),                  -- [in]
-            eventAxisCtrl        => eventAxisCtrl(i));                   -- [in]
+            eventAxisCtrl        => eventAxisCtrl(i),                    -- [in]
+            clearReadout         => clearReadout(i));                    -- [out]      
    end generate GEN_DETECTORS;
 
 


### PR DESCRIPTION
Creates a new `clearReadout` output from `TriggerEventBuffer` and `TriggerEventManager` that  pulses whenever a `CLEAR_READOUT` event is seen on the XPM bus. Clocked with `eventClk` because it will most likely be used by the same logic that receives the event stream.