### PR TITLE
Cleanup software variables

### DIFF
--- a/python/l2si_core/_XpmMini.py
+++ b/python/l2si_core/_XpmMini.py
@@ -256,20 +256,11 @@ class XpmMini(pr.Device):
         )) 
         
         self.add(pr.RemoteVariable( 
-            name         = "PartitionMessage_Insert",
+            name         = "PartitionMessage",
             offset       = 0x4C,
-            bitSize      = 1,
-            bitOffset    = 15,
-            mode         = 'WO',
-            hidden       = True,
-        )) 
-        
-        self.add(pr.RemoteVariable( 
-            name         = "PartitionMessage_Hdr",
-            offset       = 0x4C,
-            bitSize      = 8,
+            bitSize      = 16,
             bitOffset    = 0,
-            mode         = 'RW',
+            mode         = 'WO',
             hidden       = True,
         )) 
         


### PR DESCRIPTION
Merge two fields belonging to one 32b register into one field to work around coherence issue.  This should always be a single transaction anyways.