### PR TITLE
Delay transitions like L0Accepts.

### DIFF
--- a/xpm/rtl/XpmL1Router.vhd
+++ b/xpm/rtl/XpmL1Router.vhd
@@ -26,6 +26,9 @@ use surf.AxiStreamPkg.all;
 library l2si_core;
 use l2si_core.XpmPkg.all;
 
+--
+--  Still need to route l1 feedback upstream when we are not mastering the partition
+--
 entity XpmL1Router is
     generic (
        TPD_G       : time         := 1 ns;
@@ -68,6 +71,12 @@ begin
             l1FeedbacksOut(i).valid <= '0';
          end if;
       end loop;
+
+      -- Complete implementation
+      req <= vreq;
+
+      l1FeedbacksOut(XPM_PARTITIONS_C) <= XPM_L1_FEEDBACK_INIT_C;
+        
    end process comb;
   
    GEN_PARTITION : for i in 0 to XPM_PARTITIONS_C-1 generate

--- a/xpm/rtl/XpmSequence.vhd
+++ b/xpm/rtl/XpmSequence.vhd
@@ -105,6 +105,10 @@ begin
 
    timingDataOut <= r_in.data;
 
+   status.nexptseq    <= toSlv(XPM_SEQ_DEPTH_C,status.nexptseq'length);
+   status.seqaddrlen  <= toSlv(SEQADDRLEN,status.seqaddrlen'length);
+   status.countUpdate <= '0';
+                      
    U_FIFO : entity surf.AxiStreamFifoV2
       generic map (
          TPD_G               => TPD_G,


### PR DESCRIPTION
Need to delay transition messages similar to events for each partition in the XPM.  Not necessary for XpmMini.