### PR TITLE
V3.1.0 timing message out

### DIFF
--- a/base/rtl/TriggerEventBuffer.vhd
+++ b/base/rtl/TriggerEventBuffer.vhd
@@ -73,7 +73,7 @@ entity TriggerEventBuffer is
       eventRst                : in  sl;
       eventTimingMessageValid : out sl;
       eventTimingMessage      : out TimingMessageType;
-      eventTimingMessageRd    : in  sl;
+      eventTimingMessageRd    : in  sl := '1';
       eventAxisMaster         : out AxiStreamMasterType;
       eventAxisSlave          : in  AxiStreamSlaveType;
       eventAxisCtrl           : in  AxiStreamCtrlType);

--- a/base/rtl/TriggerEventBuffer.vhd
+++ b/base/rtl/TriggerEventBuffer.vhd
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
--- Description: 
+-- Description:
 -------------------------------------------------------------------------------
 -- This file is part of 'L2SI Core'. It is subject to
 -- the license terms in the LICENSE.txt file found in the top-level directory
@@ -110,7 +110,7 @@ architecture rtl of TriggerEventBuffer is
 
       fifoAxisMaster : AxiStreamMasterType;
       msgFifoWr      : sl;
-      
+
       -- outputs
       triggerData    : XpmEventDataType;
       axilReadSlave  : AxiLiteReadSlaveType;
@@ -153,7 +153,7 @@ architecture rtl of TriggerEventBuffer is
 
       fifoAxisMaster => axiStreamMasterInit(EVENT_AXIS_CONFIG_C),
       msgFifoWr      => '0',
-      
+
       -- outputs     =>
       triggerData    => XPM_EVENT_DATA_INIT_C,
       axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
@@ -243,7 +243,7 @@ begin
          -- Pass on transitions
          v.streamValid := (v.eventData.valid and v.eventData.l0Accept) or v.transitionData.valid;
          v.msgFifoWr   := (v.eventData.valid and v.eventData.l0Accept);
-         
+
          -- Don't pass data through when disabled
          if (r.enable = '0') then
             v.streamValid := '0';
@@ -502,4 +502,3 @@ begin
    eventTimingMessage <= toTimingMessageType(eventTimingMessageSlv);
 
 end architecture rtl;
-

--- a/base/rtl/TriggerEventManager.vhd
+++ b/base/rtl/TriggerEventManager.vhd
@@ -58,7 +58,7 @@ entity TriggerEventManager is
       timingTxRst : in  sl;
       timingTxPhy : out TimingPhyType;
 
-      -- Triggers 
+      -- Triggers
       triggerClk  : in  sl;
       triggerRst  : in  sl;
       triggerData : out TriggerEventDataArray(NUM_DETECTORS_G-1 downto 0);
@@ -225,7 +225,7 @@ begin
          mAxiWriteSlave  => timingAxilWriteSlave);  -- [in]
 
    -----------------------------------------------
-   -- Fan out AXI-Lite 
+   -- Fan out AXI-Lite
    -----------------------------------------------
    U_AxiLiteCrossbar_1 : entity surf.AxiLiteCrossbar
       generic map (
@@ -283,7 +283,7 @@ begin
             axilReadSlave           => locAxilReadSlaves(AXIL_TEB_C(i)),    -- [out]
             axilWriteMaster         => locAxilWriteMasters(AXIL_TEB_C(i)),  -- [in]
             axilWriteSlave          => locAxilWriteSlaves(AXIL_TEB_C(i)),   -- [out]
-            promptTimingStrobe      => timingBus.strobe,                    -- [in]            
+            promptTimingStrobe      => timingBus.strobe,                    -- [in]
             promptTimingMessage     => timingBus.message,                   -- [in]
             promptXpmMessage        => xpmMessage,                          -- [in]
             alignedTimingstrobe     => alignedTimingStrobe,                 -- [in]

--- a/base/rtl/TriggerEventManager.vhd
+++ b/base/rtl/TriggerEventManager.vhd
@@ -71,12 +71,14 @@ entity TriggerEventManager is
       l1Acks      : out slv(NUM_DETECTORS_G-1 downto 0);
 
       -- Output Streams
-      eventClk            : in  sl;
-      eventRst            : in  sl;
-      eventTimingMessages : out TimingMessageArray(NUM_DETECTORS_G-1 downto 0);
-      eventAxisMasters    : out AxiStreamMasterArray(NUM_DETECTORS_G-1 downto 0);
-      eventAxisSlaves     : in  AxiStreamSlaveArray(NUM_DETECTORS_G-1 downto 0);
-      eventAxisCtrl       : in  AxiStreamCtrlArray(NUM_DETECTORS_G-1 downto 0);
+      eventClk                 : in  sl;
+      eventRst                 : in  sl;
+      eventTimingMessagesValid : out slv(NUM_DETECTORS_G-1 downto 0);
+      eventTimingMessages      : out TimingMessageArray(NUM_DETECTORS_G-1 downto 0);
+      eventTimingMessagesRd    : in  slv(NUM_DETECTORS_G-1 downto 0);
+      eventAxisMasters         : out AxiStreamMasterArray(NUM_DETECTORS_G-1 downto 0);
+      eventAxisSlaves          : in  AxiStreamSlaveArray(NUM_DETECTORS_G-1 downto 0);
+      eventAxisCtrl            : in  AxiStreamCtrlArray(NUM_DETECTORS_G-1 downto 0);
 
       -- AXI-Lite
       axilClk         : in  sl;
@@ -275,31 +277,33 @@ begin
             TRIGGER_CLK_IS_TIMING_RX_CLK_G => TRIGGER_CLK_IS_TIMING_RX_CLK_G,
             EVENT_CLK_IS_TIMING_RX_CLK_G   => EVENT_CLK_IS_TIMING_RX_CLK_G)
          port map (
-            timingRxClk          => timingRxClk,                         -- [in]
-            timingRxRst          => timingRxRst,                         -- [in]
-            axilReadMaster       => locAxilReadMasters(AXIL_TEB_C(i)),   -- [in]
-            axilReadSlave        => locAxilReadSlaves(AXIL_TEB_C(i)),    -- [out]
-            axilWriteMaster      => locAxilWriteMasters(AXIL_TEB_C(i)),  -- [in]
-            axilWriteSlave       => locAxilWriteSlaves(AXIL_TEB_C(i)),   -- [out]
-            promptTimingStrobe   => timingBus.strobe,                    -- [in]            
-            promptTimingMessage  => timingBus.message,                   -- [in]
-            promptXpmMessage     => xpmMessage,                          -- [in]
-            alignedTimingstrobe  => alignedTimingStrobe,                 -- [in]
-            alignedTimingMessage => alignedTimingMessage,                -- [in]
-            alignedXpmMessage    => alignedXpmMessage,                   -- [in]
-            partition            => detectorPartitions(i),               -- [out]
-            pause                => pause(i),                            -- [out]
-            overflow             => overflow(i),                         -- [out]
-            triggerClk           => triggerClk,                          -- [in]
-            triggerRst           => triggerRst,                          -- [in]
-            triggerData          => triggerData(i),                      -- [out]
-            clear                => clear(i),                            -- [out]
-            eventClk             => eventClk,                            -- [in]
-            eventRst             => eventRst,                            -- [in]
-            eventTimingMessage   => eventTimingMessages(i),              -- [out]
-            eventAxisMaster      => eventAxisMasters(i),                 -- [out]
-            eventAxisSlave       => eventAxisSlaves(i),                  -- [in]
-            eventAxisCtrl        => eventAxisCtrl(i));                   -- [in]
+            timingRxClk             => timingRxClk,                         -- [in]
+            timingRxRst             => timingRxRst,                         -- [in]
+            axilReadMaster          => locAxilReadMasters(AXIL_TEB_C(i)),   -- [in]
+            axilReadSlave           => locAxilReadSlaves(AXIL_TEB_C(i)),    -- [out]
+            axilWriteMaster         => locAxilWriteMasters(AXIL_TEB_C(i)),  -- [in]
+            axilWriteSlave          => locAxilWriteSlaves(AXIL_TEB_C(i)),   -- [out]
+            promptTimingStrobe      => timingBus.strobe,                    -- [in]            
+            promptTimingMessage     => timingBus.message,                   -- [in]
+            promptXpmMessage        => xpmMessage,                          -- [in]
+            alignedTimingstrobe     => alignedTimingStrobe,                 -- [in]
+            alignedTimingMessage    => alignedTimingMessage,                -- [in]
+            alignedXpmMessage       => alignedXpmMessage,                   -- [in]
+            partition               => detectorPartitions(i),               -- [out]
+            pause                   => pause(i),                            -- [out]
+            overflow                => overflow(i),                         -- [out]
+            triggerClk              => triggerClk,                          -- [in]
+            triggerRst              => triggerRst,                          -- [in]
+            triggerData             => triggerData(i),                      -- [out]
+            clear                   => clear(i),                            -- [out]
+            eventClk                => eventClk,                            -- [in]
+            eventRst                => eventRst,                            -- [in]
+            eventTimingMessageValid => eventTimingMessagesValid(i),         -- [out]
+            eventTimingMessage      => eventTimingMessages(i),              -- [out]
+            eventTimingMessageRd    => eventTimingMessagesRd(i),            -- [in]
+            eventAxisMaster         => eventAxisMasters(i),                 -- [out]
+            eventAxisSlave          => eventAxisSlaves(i),                  -- [in]
+            eventAxisCtrl           => eventAxisCtrl(i));                   -- [in]
    end generate GEN_DETECTORS;
 
 

--- a/base/rtl/TriggerEventManager.vhd
+++ b/base/rtl/TriggerEventManager.vhd
@@ -75,7 +75,7 @@ entity TriggerEventManager is
       eventRst                 : in  sl;
       eventTimingMessagesValid : out slv(NUM_DETECTORS_G-1 downto 0);
       eventTimingMessages      : out TimingMessageArray(NUM_DETECTORS_G-1 downto 0);
-      eventTimingMessagesRd    : in  slv(NUM_DETECTORS_G-1 downto 0);
+      eventTimingMessagesRd    : in  slv(NUM_DETECTORS_G-1 downto 0) := (others=>'1');
       eventAxisMasters         : out AxiStreamMasterArray(NUM_DETECTORS_G-1 downto 0);
       eventAxisSlaves          : in  AxiStreamSlaveArray(NUM_DETECTORS_G-1 downto 0);
       eventAxisCtrl            : in  AxiStreamCtrlArray(NUM_DETECTORS_G-1 downto 0);


### PR DESCRIPTION
Fix the application interface to get the timing message for event-dependent processing.  Previously, it's control signals were tied to the axi-stream master/slave.