### PR TITLE
Fix Partition Message Generation Issue

### DIFF
--- a/python/l2si_core/_XpmMini.py
+++ b/python/l2si_core/_XpmMini.py
@@ -256,25 +256,15 @@ class XpmMini(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
-            name         = "PartitionMessage_Insert",
-            offset       = 0x4C,
-            bitSize      = 1,
-            bitOffset    = 15,
-            mode         = 'WO',
-            hidden       = True,
-        ))
-
-        self.add(pr.RemoteVariable(
             name         = "PartitionMessage_Hdr",
             offset       = 0x4C,
-            bitSize      = 8,
+            bitSize      = 16,
             bitOffset    = 0,
-            mode         = 'RW',
+            mode         = 'WO',
             hidden       = True,
         ))
 
 
         @self.command()
         def SendTransition(arg):
-            self.PartitionMessage_Hdr.set(arg)
-            self.PartitionMessage_Insert.set(1)
+            self.PartitionMessage_Hdr.set(arg | (1<<15))

--- a/xpm/rtl/XpmPkg.vhd
+++ b/xpm/rtl/XpmPkg.vhd
@@ -41,6 +41,10 @@ package XpmPkg is
    constant XPM_NUM_L1_TRIGGERS_C : integer := 1;
    constant XPM_LCTR_DEPTH_C      : integer := 40;
 
+   --  Async ethernet message types
+   constant XPM_MESSAGE_SEQUENCE_DONE : slv(15 downto 0) := toSlv(0,16);
+   constant XPM_MESSAGE_STEP_DONE     : slv(15 downto 0) := toSlv(1,16);
+   
    -- This doesn't belong here but not sure where to move it
    constant NSTREAMS_C : integer := 3;
 

--- a/xpm/rtl/XpmSequence.vhd
+++ b/xpm/rtl/XpmSequence.vhd
@@ -239,7 +239,7 @@ begin
       end loop;
 
       v.master.tLast := '1';
-      v.master.tKeep := genTKeep(XPM_SEQ_DEPTH_C*2+2);
+      v.master.tKeep := genTKeep(XPM_SEQ_DEPTH_C*2+4);
 
       if axisSlave.tReady = '1' then
          v.master.tValid := '0';
@@ -250,10 +250,10 @@ begin
          ssiSetUserSof (EMAC_AXIS_CONFIG_C, v.master, '1');
          ssiSetUserEofe(EMAC_AXIS_CONFIG_C, v.master, '0');
          v.master.tValid             := '1';
-         v.master.tData(15 downto 0) := resize(seqNotifyValid, 16);
+         v.master.tData(31 downto 0) := resize(seqNotifyValid, 16) & XPM_MESSAGE_SEQUENCE_DONE;
          for i in 0 to XPM_SEQ_DEPTH_C-1 loop
             if seqNotifyValid(i) = '1' then
-               v.master.tData(16*i+31 downto 16*i+16) := resize(slv(seqNotify(i)), 16);
+               v.master.tData(16*i+47 downto 16*i+32) := resize(slv(seqNotify(i)), 16);
             end if;
          end loop;
       end if;


### PR DESCRIPTION
 - Add 16b header word to async eth message.
 - Enable inhibiting of partition messages.  
 - Reduce partition message configuration to one register.

Addresses message generation issue.  Often see two partition messages generated from a single call.