### PR TITLE
Allow EVR triggers in LCLS-II mode

### DIFF
--- a/base/rtl/L2SiPkg.vhd
+++ b/base/rtl/L2SiPkg.vhd
@@ -44,6 +44,9 @@ package L2SiPkg is
    subtype TriggerL1FeedbackArray is XpmL1FeedbackArray;
    constant TRIGGER_L1_FEEDBACK_INIT_C : TriggerL1FeedbackType := XPM_L1_FEEDBACK_INIT_C;
 
+   constant XPM_TRIGGER_SOURCE_C : sl := '0';
+   constant EVR_TRIGGER_SOURCE_C : sl := '1';
+
    ----------------------------------------------------
    -- Event and Timing Header interface
    ----------------------------------------------------

--- a/base/rtl/TriggerEventBuffer.vhd
+++ b/base/rtl/TriggerEventBuffer.vhd
@@ -118,7 +118,7 @@ architecture rtl of TriggerEventBuffer is
       msgFifoWr      : sl;
 
       -- outputs
-      triggerData    : XpmEventDataType;
+      triggerData : XpmEventDataType;
 
       -- debug
       partitionV     : integer;
@@ -132,10 +132,10 @@ architecture rtl of TriggerEventBuffer is
    end record RegType;
 
    constant REG_INIT_C : RegType := (
-      evrTrigLast     => '0',
-      partition       => (others => '0'),
-      overflow        => '0',
-      fifoRst         => '0',
+      evrTrigLast => '0',
+      partition   => (others => '0'),
+      overflow    => '0',
+      fifoRst     => '0',
 
       transitionCount => (others => '0'),
       validCount      => (others => '0'),
@@ -156,7 +156,7 @@ architecture rtl of TriggerEventBuffer is
       msgFifoWr      => '0',
 
       -- outputs     =>
-      triggerData    => TRIGGER_EVENT_DATA_INIT_C,
+      triggerData => TRIGGER_EVENT_DATA_INIT_C,
 
       partitionV     => 0,
       eventData      => XPM_EVENT_DATA_INIT_C,
@@ -186,6 +186,7 @@ architecture rtl of TriggerEventBuffer is
 
    signal partitionReg    : slv(2 downto 0);
    signal triggerDelay    : slv(31 downto 0);
+   signal triggerSource   : sl;
    signal fifoPauseThresh : slv(FIFO_ADDR_WIDTH_C-1 downto 0);
    signal resetCounters   : sl;
    signal fifoRstReg      : sl;
@@ -214,8 +215,11 @@ begin
    begin
       v := r;
 
-      if (EN_LCLS_I_TIMING_G and timingMode = '0') then
-         -- LCLS-I EVR Trigger buffer logic
+      if ((EN_LCLS_I_TIMING_G and timingMode = '0') or
+          (EN_LCLS_II_TIMING_G and timingMode = '1' and triggerSource = EVR_TRIGGER_SOURCE_C)) then
+
+         -- EVR trigger logic
+         -- Mislabled as "EVR", can come in LCLS-II timing
          v.fifoRst               := '0';
          v.fifoAxisMaster.tValid := '0';
          v.triggerData.valid     := '0';
@@ -240,17 +244,9 @@ begin
 
          end if;
 
-         if (fifoAxisCtrl.overflow = '1') then
-            v.overflow := '1';
-         end if;
+      elsif (EN_LCLS_II_TIMING_G and timingMode = '1' and triggerSource = XPM_TRIGGER_SOURCE_C) then
 
-         if (resetCounters = '1') then
-            v.triggerCount := (others => '0');
-         end if;
-
-      elsif (EN_LCLS_II_TIMING_G and timingMode = '1') then
          -- LCLS-II XPM Trigger Buffer Logic
-
          v.partitionV            := conv_integer(r.partition);
          v.fifoRst               := '0';
          v.fifoAxisMaster.tValid := '0';
@@ -329,10 +325,6 @@ begin
 
          end if;
 
-         -- Latch FIFO overflow if seen
-         if (fifoAxisCtrl.overflow = '1') then
-            v.overflow := '1';
-         end if;
 
          -- Count stuff
          if (r.streamValid = '1') then
@@ -376,6 +368,11 @@ begin
             end if;
          end if;
 
+      end if;  -- LCLS-II XPM logic 
+
+      -- Latch FIFO overflow if seen
+      if (fifoAxisCtrl.overflow = '1') then
+         v.overflow := '1';
       end if;
 
       if (resetCounters = '1') then
@@ -397,11 +394,11 @@ begin
       rin <= v;
 
       -- outputs
-      fifoRst        <= r.fifoRst or fifoRstReg;
+      fifoRst <= r.fifoRst or fifoRstReg;
 
-      partition      <= r.partition;
-      overflow       <= r.overflow;
-      pause          <= r.pause;
+      partition <= r.partition;
+      overflow  <= r.overflow;
+      pause     <= r.pause;
 
    end process comb;
 
@@ -441,6 +438,7 @@ begin
          resetCounters     => resetCounters,
          partition         => partitionReg,
          triggerDelay      => triggerDelay,
+         triggerSource     => triggerSource,
          fifoPauseThresh   => fifoPauseThresh,
          -- AXI Lite bus for configuration and status
          axilClk           => axilClk,
@@ -453,7 +451,7 @@ begin
    -----------------------------------------------
    -- Delay triggerData according to AXI-Lite register
    -----------------------------------------------
-   triggerDataSlv <= toSlv(r.triggerData);
+   triggerDataSlv   <= toSlv(r.triggerData);
    triggerDataValid <= r.triggerData.valid and r.triggerData.l0Accept;
    U_SlvDelayFifo_1 : entity surf.SlvDelayFifo
       generic map (
@@ -521,17 +519,17 @@ begin
          SLAVE_AXI_CONFIG_G  => EVENT_AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => EVENT_AXIS_CONFIG_G)
       port map (
-         sAxisClk        => timingRxClk,        -- [in]
-         sAxisRst        => fifoRst,            -- [in]
-         sAxisMaster     => r.fifoAxisMaster,   -- [in]
-         sAxisSlave      => fifoAxisSlave,      -- [out]
-         sAxisCtrl       => fifoAxisCtrl,       -- [out]
-         fifoPauseThresh => fifoPauseThresh,    -- [in]
-         fifoWrCnt       => fifoWrCnt,          -- [out]
-         mAxisClk        => eventClk,           -- [in]
-         mAxisRst        => eventRst,           -- [in]
-         mAxisMaster     => eventAxisMaster,    -- [out]
-         mAxisSlave      => eventAxisSlave);    -- [in]
+         sAxisClk        => timingRxClk,       -- [in]
+         sAxisRst        => fifoRst,           -- [in]
+         sAxisMaster     => r.fifoAxisMaster,  -- [in]
+         sAxisSlave      => fifoAxisSlave,     -- [out]
+         sAxisCtrl       => fifoAxisCtrl,      -- [out]
+         fifoPauseThresh => fifoPauseThresh,   -- [in]
+         fifoWrCnt       => fifoWrCnt,         -- [out]
+         mAxisClk        => eventClk,          -- [in]
+         mAxisRst        => eventRst,          -- [in]
+         mAxisMaster     => eventAxisMaster,   -- [out]
+         mAxisSlave      => eventAxisSlave);   -- [in]
 
    -----------------------------------------------
    -- Buffer TimingMessage that corresponds to each event placed in event fifo

--- a/base/rtl/TriggerEventBuffer.vhd
+++ b/base/rtl/TriggerEventBuffer.vhd
@@ -207,9 +207,10 @@ begin
          dataOut => eventAxisCtrlPauseSync);  -- [out]
 
 
-   comb : process (alignedTimingMessage, alignedTimingStrobe, alignedXpmMessage, axilReadMaster,
-                   axilWriteMaster, eventAxisCtrlPauseSync, enable, evrTriggers, fifoAxisCtrl, fifoRstReg,
-                   partitionReg, promptTimingStrobe, promptXpmMessage, r, resetCounters, timingMode, timingRxRst) is
+   comb : process (alignedTimingMessage, alignedTimingStrobe, alignedXpmMessage, enable,
+                   eventAxisCtrlPauseSync, evrTriggers, fifoAxisCtrl, fifoRstReg, partitionReg,
+                   promptTimingStrobe, promptXpmMessage, r, resetCounters, timingMode, timingRxRst,
+                   triggerSource) is
       variable v      : RegType;
       variable axilEp : AxiLiteEndpointType;
    begin

--- a/base/rtl/TriggerEventBufferReg.vhd
+++ b/base/rtl/TriggerEventBufferReg.vhd
@@ -309,7 +309,7 @@ begin
       -- LCLS-II only registers
       if (EN_LCLS_II_TIMING_G) then
          axiSlaveRegister(axilEp, x"04", 0, v.partition);
-         axiSlaveRegister(axilEp, x"04", 15, v.triggerSource);
+         axiSlaveRegister(axilEp, x"04", 16, v.triggerSource);
          axiSlaveRegister(axilEp, X"0C", 0, v.triggerDelay);
          axiSlaveRegister(axilEp, X"08", 0, v.fifoPauseThresh);
          axiSlaveRegisterR(axilEp, X"10", 1, pauseSync);

--- a/base/rtl/TriggerEventBufferReg.vhd
+++ b/base/rtl/TriggerEventBufferReg.vhd
@@ -57,6 +57,7 @@ entity TriggerEventBufferReg is
       resetCounters     : out sl;
       partition         : out slv(2 downto 0);
       triggerDelay      : out slv(31 downto 0);
+      triggerSource     : out sl;
       fifoPauseThresh   : out slv(FIFO_ADDR_WIDTH_G-1 downto 0);
       -- AXI Lite bus for configuration and status
       axilClk           : in  sl;
@@ -75,6 +76,7 @@ architecture rtl of TriggerEventBufferReg is
       resetCounters   : sl;
       partition       : slv(2 downto 0);
       triggerDelay    : slv(31 downto 0);
+      triggerSource   : sl;
       fifoPauseThresh : slv(FIFO_ADDR_WIDTH_G-1 downto 0);
       axilReadSlave   : AxiLiteReadSlaveType;
       axilWriteSlave  : AxiLiteWriteSlaveType;
@@ -86,6 +88,7 @@ architecture rtl of TriggerEventBufferReg is
       resetCounters   => '0',
       partition       => (others => '0'),
       triggerDelay    => toSlv(42, 32),
+      triggerSource   => XPM_TRIGGER_SOURCE_C,
       fifoPauseThresh => toslv(16, FIFO_ADDR_WIDTH_G),
       axilReadSlave   => AXI_LITE_READ_SLAVE_INIT_C,
       axilWriteSlave  => AXI_LITE_WRITE_SLAVE_INIT_C);
@@ -306,6 +309,7 @@ begin
       -- LCLS-II only registers
       if (EN_LCLS_II_TIMING_G) then
          axiSlaveRegister(axilEp, x"04", 0, v.partition);
+         axiSlaveRegister(axilEp, x"04", 0, v.triggerSource);
          axiSlaveRegister(axilEp, X"0C", 0, v.triggerDelay);
          axiSlaveRegister(axilEp, X"08", 0, v.fifoPauseThresh);
          axiSlaveRegisterR(axilEp, X"10", 1, pauseSync);
@@ -318,6 +322,7 @@ begin
          axiSlaveRegisterR(axilEp, X"30", 0, partitionWord0Sync);
          axiSlaveRegisterR(axilEp, X"38", 0, pauseToTrigSync);
          axiSlaveRegisterR(axilEp, X"3C", 0, notPauseToTrigSync);
+
       end if;
 
       axiSlaveDefault(axilEp, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_DECERR_C);
@@ -345,11 +350,13 @@ begin
       generic map (
          TPD_G         => TPD_G,
          BYPASS_SYNC_G => COMMON_CLK_G,
-         WIDTH_G       => 1)
+         WIDTH_G       => 2)
       port map (
          clk        => timingRxClk,
          dataIn(0)  => r.enable,
-         dataOut(0) => enable);
+         dataIn(1)  => r.triggerSource,
+         dataOut(0) => enable,
+         dataOut(1) => triggerSource);
 
    U_fifoRst : entity surf.SynchronizerOneShot
       generic map (

--- a/base/rtl/TriggerEventBufferReg.vhd
+++ b/base/rtl/TriggerEventBufferReg.vhd
@@ -309,7 +309,7 @@ begin
       -- LCLS-II only registers
       if (EN_LCLS_II_TIMING_G) then
          axiSlaveRegister(axilEp, x"04", 0, v.partition);
-         axiSlaveRegister(axilEp, x"04", 0, v.triggerSource);
+         axiSlaveRegister(axilEp, x"04", 15, v.triggerSource);
          axiSlaveRegister(axilEp, X"0C", 0, v.triggerDelay);
          axiSlaveRegister(axilEp, X"08", 0, v.fifoPauseThresh);
          axiSlaveRegisterR(axilEp, X"10", 1, pauseSync);

--- a/base/rtl/TriggerEventManager.vhd
+++ b/base/rtl/TriggerEventManager.vhd
@@ -72,7 +72,7 @@ entity TriggerEventManager is
       eventRst                 : in  sl;
       eventTimingMessagesValid : out slv(NUM_DETECTORS_G-1 downto 0);
       eventTimingMessages      : out TimingMessageArray(NUM_DETECTORS_G-1 downto 0);
-      eventTimingMessagesRd    : in  slv(NUM_DETECTORS_G-1 downto 0) := (others=>'1');
+      eventTimingMessagesRd    : in  slv(NUM_DETECTORS_G-1 downto 0) := (others => '1');
       eventAxisMasters         : out AxiStreamMasterArray(NUM_DETECTORS_G-1 downto 0);
       eventAxisSlaves          : in  AxiStreamSlaveArray(NUM_DETECTORS_G-1 downto 0);
       eventAxisCtrl            : in  AxiStreamCtrlArray(NUM_DETECTORS_G-1 downto 0);
@@ -256,44 +256,43 @@ begin
          NUM_MASTER_SLOTS_G => AXIL_MASTERS_C,
          MASTERS_CONFIG_G   => AXIL_XBAR_CONFIG_C)
       port map (
-         axiClk              => axilClk,                -- [in]
-         axiClkRst           => axilRst,                -- [in]
-         sAxiWriteMasters(0) => axilWriteMaster,        -- [in]
-         sAxiWriteSlaves(0)  => axilWriteSlave,         -- [out]
-         sAxiReadMasters(0)  => axilReadMaster,         -- [in]
-         sAxiReadSlaves(0)   => axilReadSlave,          -- [out]
-         mAxiWriteMasters    => locAxilWriteMasters,    -- [out]
-         mAxiWriteSlaves     => locAxilWriteSlaves,     -- [in]
-         mAxiReadMasters     => locAxilReadMasters,     -- [out]
-         mAxiReadSlaves      => locAxilReadSlaves);     -- [in]
+         axiClk              => axilClk,              -- [in]
+         axiClkRst           => axilRst,              -- [in]
+         sAxiWriteMasters(0) => axilWriteMaster,      -- [in]
+         sAxiWriteSlaves(0)  => axilWriteSlave,       -- [out]
+         sAxiReadMasters(0)  => axilReadMaster,       -- [in]
+         sAxiReadSlaves(0)   => axilReadSlave,        -- [out]
+         mAxiWriteMasters    => locAxilWriteMasters,  -- [out]
+         mAxiWriteSlaves     => locAxilWriteSlaves,   -- [in]
+         mAxiReadMasters     => locAxilReadMasters,   -- [out]
+         mAxiReadSlaves      => locAxilReadSlaves);   -- [in]
 
    -------------------------------------------------------------------------------------------------
    -- LCLS-I timing uses EvrV2CoreTrigers to decode triggers from the EVR timing stream
+   -- LCLS-II timing uses EvrV2CoreTrigers to decode triggers from the LCLS-II timing stream
    -------------------------------------------------------------------------------------------------
-   EVR_GEN : if (EN_LCLS_I_TIMING_G) generate
-      U_EvrV2CoreTriggers_1 : entity lcls_timing_core.EvrV2CoreTriggers
-         generic map (
-            TPD_G           => TPD_G,
-            NCHANNELS_G     => NUM_DETECTORS_G,
-            NTRIGGERS_G     => NUM_DETECTORS_G,
-            TRIG_DEPTH_G    => 28,
-            TRIG_PIPE_G     => 0,
-            COMMON_CLK_G    => AXIL_CLK_IS_TIMING_RX_CLK_G,
-            EVR_CARD_G      => false,
-            AXIL_BASEADDR_G => AXIL_XBAR_CONFIG_C(AXIL_EVR_C).baseAddr)
-         port map (
-            axilClk         => axilClk,                          -- [in]
-            axilRst         => axilRst,                          -- [in]
-            axilWriteMaster => locAxilWriteMasters(AXIL_EVR_C),  -- [in]
-            axilWriteSlave  => locAxilWriteSlaves(AXIL_EVR_C),   -- [out]
-            axilReadMaster  => locAxilReadMasters(AXIL_EVR_C),   -- [in]
-            axilReadSlave   => locAxilReadSlaves(AXIL_EVR_C),    -- [out]
-            evrClk          => timingRxClk,                      -- [in]
-            evrRst          => timingRxRst,                      -- [in]
-            evrBus          => timingBus,                        -- [in]
-            trigOut         => evrTriggers,                      -- [out]
-            evrModeSel      => '0');                             -- [in]
-   end generate EVR_GEN;
+   U_EvrV2CoreTriggers_1 : entity lcls_timing_core.EvrV2CoreTriggers
+      generic map (
+         TPD_G           => TPD_G,
+         NCHANNELS_G     => NUM_DETECTORS_G,
+         NTRIGGERS_G     => NUM_DETECTORS_G,
+         TRIG_DEPTH_G    => 28,
+         TRIG_PIPE_G     => 0,
+         COMMON_CLK_G    => AXIL_CLK_IS_TIMING_RX_CLK_G,
+         EVR_CARD_G      => false,
+         AXIL_BASEADDR_G => AXIL_XBAR_CONFIG_C(AXIL_EVR_C).baseAddr)
+      port map (
+         axilClk         => axilClk,                          -- [in]
+         axilRst         => axilRst,                          -- [in]
+         axilWriteMaster => locAxilWriteMasters(AXIL_EVR_C),  -- [in]
+         axilWriteSlave  => locAxilWriteSlaves(AXIL_EVR_C),   -- [out]
+         axilReadMaster  => locAxilReadMasters(AXIL_EVR_C),   -- [in]
+         axilReadSlave   => locAxilReadSlaves(AXIL_EVR_C),    -- [out]
+         evrClk          => timingRxClk,                      -- [in]
+         evrRst          => timingRxRst,                      -- [in]
+         evrBus          => timingBus,                        -- [in]
+         trigOut         => evrTriggers,                      -- [out]
+         evrModeSel      => '0');                             -- [in]
 
    -------------------------------------------------------------------------------------------------
    -- LCLS-II uses the XPM extension stream
@@ -341,37 +340,37 @@ begin
             TRIGGER_CLK_IS_TIMING_RX_CLK_G => TRIGGER_CLK_IS_TIMING_RX_CLK_G,
             EVENT_CLK_IS_TIMING_RX_CLK_G   => EVENT_CLK_IS_TIMING_RX_CLK_G)
          port map (
-            timingRxClk          => timingRxClk,                         -- [in]
-            timingRxRst          => timingRxRst,                         -- [in]
-            axilClk              => axilClk,                             -- [in]
-            axilRst              => axilRst,                             -- [in]
-            axilReadMaster       => locAxilReadMasters(AXIL_TEB_C(i)),   -- [in]
-            axilReadSlave        => locAxilReadSlaves(AXIL_TEB_C(i)),    -- [out]
-            axilWriteMaster      => locAxilWriteMasters(AXIL_TEB_C(i)),  -- [in]
-            axilWriteSlave       => locAxilWriteSlaves(AXIL_TEB_C(i)),   -- [out]
-            timingMode           => timingMode,                          -- [in]
-            evrTriggers          => evrTriggers,                         -- [out]
-            promptTimingStrobe   => timingBus.strobe,                    -- [in]
-            promptTimingMessage  => timingBus.message,                   -- [in]
-            promptXpmMessage     => xpmMessage,                          -- [in]
-            alignedTimingstrobe  => alignedTimingStrobe,                 -- [in]
-            alignedTimingMessage => alignedTimingMessage,                -- [in]
-            alignedXpmMessage    => alignedXpmMessage,                   -- [in]
-            partition            => detectorPartitions(i),               -- [out]
-            pause                => pause(i),                            -- [out]
-            overflow             => overflow(i),                         -- [out]
-            triggerClk           => triggerClk,                          -- [in]
-            triggerRst           => triggerRst,                          -- [in]
-            triggerData          => triggerData(i),                      -- [out]
-            eventClk             => eventClk,                            -- [in]
-            eventRst             => eventRst,                            -- [in]
-            eventTimingMessageValid => eventTimingMessagesValid(i),      -- [out]
-            eventTimingMessage   => eventTimingMessages(i),              -- [out]
-            eventTimingMessageRd => eventTimingMessagesRd(i),            -- [in]
-            eventAxisMaster      => eventAxisMasters(i),                 -- [out]
-            eventAxisSlave       => eventAxisSlaves(i),                  -- [in]
-            eventAxisCtrl        => eventAxisCtrl(i),                    -- [in]
-            clearReadout         => clearReadout(i));                    -- [out]
+            timingRxClk             => timingRxClk,                         -- [in]
+            timingRxRst             => timingRxRst,                         -- [in]
+            axilClk                 => axilClk,                             -- [in]
+            axilRst                 => axilRst,                             -- [in]
+            axilReadMaster          => locAxilReadMasters(AXIL_TEB_C(i)),   -- [in]
+            axilReadSlave           => locAxilReadSlaves(AXIL_TEB_C(i)),    -- [out]
+            axilWriteMaster         => locAxilWriteMasters(AXIL_TEB_C(i)),  -- [in]
+            axilWriteSlave          => locAxilWriteSlaves(AXIL_TEB_C(i)),   -- [out]
+            timingMode              => timingMode,                          -- [in]
+            evrTriggers             => evrTriggers,                         -- [out]
+            promptTimingStrobe      => timingBus.strobe,                    -- [in]
+            promptTimingMessage     => timingBus.message,                   -- [in]
+            promptXpmMessage        => xpmMessage,                          -- [in]
+            alignedTimingstrobe     => alignedTimingStrobe,                 -- [in]
+            alignedTimingMessage    => alignedTimingMessage,                -- [in]
+            alignedXpmMessage       => alignedXpmMessage,                   -- [in]
+            partition               => detectorPartitions(i),               -- [out]
+            pause                   => pause(i),                            -- [out]
+            overflow                => overflow(i),                         -- [out]
+            triggerClk              => triggerClk,                          -- [in]
+            triggerRst              => triggerRst,                          -- [in]
+            triggerData             => triggerData(i),                      -- [out]
+            eventClk                => eventClk,                            -- [in]
+            eventRst                => eventRst,                            -- [in]
+            eventTimingMessageValid => eventTimingMessagesValid(i),         -- [out]
+            eventTimingMessage      => eventTimingMessages(i),              -- [out]
+            eventTimingMessageRd    => eventTimingMessagesRd(i),            -- [in]
+            eventAxisMaster         => eventAxisMasters(i),                 -- [out]
+            eventAxisSlave          => eventAxisSlaves(i),                  -- [in]
+            eventAxisCtrl           => eventAxisCtrl(i),                    -- [in]
+            clearReadout            => clearReadout(i));                    -- [out]
    end generate GEN_DETECTORS;
 
 

--- a/python/l2si_core/_TriggerEventBuffer.py
+++ b/python/l2si_core/_TriggerEventBuffer.py
@@ -53,6 +53,20 @@ class TriggerEventBuffer(pr.Device):
             ))
 
             self.add(pr.RemoteVariable(
+                name        = 'TriggerSource',
+                description = 'Source of trigger',
+                offset      = 0x04,
+                bitSize     = 1,
+                bitOffset   = 16,
+                base        = pr.UInt,
+                mode        = 'RW',
+                enum = {
+                    0: 'XPM',
+                    1: 'EVR'}
+            ))
+            
+
+            self.add(pr.RemoteVariable(
                 name        = 'PauseThreshold',
                 description = 'Buffer level at which Pause is asserted',
                 offset      = 0x08,

--- a/python/l2si_core/_TriggerEventBuffer.py
+++ b/python/l2si_core/_TriggerEventBuffer.py
@@ -64,7 +64,7 @@ class TriggerEventBuffer(pr.Device):
                     0: 'XPM',
                     1: 'EVR'}
             ))
-            
+
 
             self.add(pr.RemoteVariable(
                 name        = 'PauseThreshold',

--- a/xpm/rtl/XpmL0Select.vhd
+++ b/xpm/rtl/XpmL0Select.vhd
@@ -134,7 +134,7 @@ begin
          dataOut(33)           => uconfig.enabled,
          dataOut(41 downto 34) => uconfig.groups);
 
-   comb : process (r, rst, inhibit, timingBus, cuTiming, cuTimingV, uconfig, strobe) is
+   comb : process (cuTiming, inhibit, r, rst, strobe, timingBus, uconfig, ureject) is
       variable v        : RegType;
       variable m        : TimingMessageType;
       variable rateSel  : sl;


### PR DESCRIPTION
This PR adds a `TriggerSource` config bit in `TriggerEventBuffer`, which allows LCLS-II systems to use the beam timing (EVR) as a trigger source.