### PR TITLE
adding support for standAloneMode input port on TriggerEventBuffer

### DIFF
--- a/base/rtl/TriggerEventBuffer.vhd
+++ b/base/rtl/TriggerEventBuffer.vhd
@@ -41,8 +41,9 @@ entity TriggerEventBuffer is
       TRIGGER_CLK_IS_TIMING_RX_CLK_G : boolean             := false;
       EVENT_CLK_IS_TIMING_RX_CLK_G   : boolean             := false);
    port (
-      timingRxClk : in sl;
-      timingRxRst : in sl;
+      timingRxClk    : in sl;
+      timingRxRst    : in sl;
+      standAloneMode : in sl := '0'; -- 1 when using l2si_core.XpmMiniWrapper (locally)
 
       -- AXI Lite bus for configuration and status
       axilClk         : in  sl;
@@ -204,6 +205,7 @@ architecture rtl of TriggerEventBuffer is
    signal fifoRstReg      : sl;
    signal fifoRst         : sl;
    signal enable          : sl;
+   signal enableTmp       : sl;
 
    signal triggerInhibitCountsSlv : slv(XPM_INHIBIT_COUNTS_LEN_C-1 downto 0);
    signal eventInhibitCountsSlv   : slv(XPM_INHIBIT_COUNTS_LEN_C-1 downto 0);
@@ -472,7 +474,7 @@ begin
          alignedXpmMessage => alignedXpmMessage,
          pauseToTrig       => r.pauseToTrig,
          notPauseToTrig    => r.notPauseToTrig,
-         enable            => enable,
+         enable            => enableTmp,
          fifoRst           => fifoRstReg,
          resetCounters     => resetCounters,
          partition         => partitionReg,
@@ -486,6 +488,8 @@ begin
          axilReadSlave     => axilReadSlave,
          axilWriteMaster   => axilWriteMaster,
          axilWriteSlave    => axilWriteSlave);
+
+   enable <= '0' when( (standAloneMode = '1') and (eventAxisCtrlPauseSync = '1') ) else enableTmp;
 
    -----------------------------------------------
    -- Delay triggerData according to AXI-Lite register

--- a/base/rtl/TriggerEventManager.vhd
+++ b/base/rtl/TriggerEventManager.vhd
@@ -49,8 +49,9 @@ entity TriggerEventManager is
       timingRxClk : in sl;
       timingRxRst : in sl;
 
-      timingBus  : in TimingBusType;
-      timingMode : in sl;
+      timingBus      : in TimingBusType;
+      timingMode     : in sl;
+      standAloneMode : in sl := '0'; -- 1 when using l2si_core.XpmMiniWrapper (locally)
 
       -- Timing Tx Feedback
       timingTxClk : in  sl;
@@ -347,6 +348,7 @@ begin
          port map (
             timingRxClk             => timingRxClk,                         -- [in]
             timingRxRst             => timingRxRst,                         -- [in]
+            standAloneMode          => standAloneMode,                      -- [in]
             axilClk                 => axilClk,                             -- [in]
             axilRst                 => axilRst,                             -- [in]
             axilReadMaster          => locAxilReadMasters(AXIL_TEB_C(i)),   -- [in]


### PR DESCRIPTION
### Description
- This will stop triggers if eventAxisCtrl.Pause = 1 and using l2si_core.XpmMiniWrapper locally to generate triggers

### NOTE: 
- Likely we will close this PR without merging.  Matt thinks that this should already work (txPhy from TriggerEventBuffer connector to l2si.XpmMiniTpg already) and just a bug that he needs to simulate and resolve