### PR TITLE
V3.6.8 timestamp delay fix

### DIFF
--- a/base/rtl/TriggerEventBuffer.vhd
+++ b/base/rtl/TriggerEventBuffer.vhd
@@ -267,8 +267,8 @@ begin
 
          end if;
 
-         delayedTriggerDataSlv   <= toSlv(r.triggerData);
-         delayedTriggerDataValid <= r.triggerData.valid and r.triggerData.l0Accept;
+         delayedTriggerDataSlv   <= xpmTriggerDataSlv;
+         delayedTriggerDataValid <= xpmTriggerDataValid;
 
       elsif (EN_LCLS_II_TIMING_G and timingMode = '1' and triggerSource = XPM_TRIGGER_SOURCE_C) then
 

--- a/base/rtl/TriggerEventManager.vhd
+++ b/base/rtl/TriggerEventManager.vhd
@@ -281,8 +281,7 @@ begin
          TPD_G           => TPD_G,
          NCHANNELS_G     => NUM_DETECTORS_G,
          COMMON_CLK_G    => AXIL_CLK_IS_TIMING_RX_CLK_G,
-         EVR_CARD_G      => false,
-         AXIL_BASEADDR_G => AXIL_XBAR_CONFIG_C(AXIL_EVR_C).baseAddr)
+         EVR_CARD_G      => false)
       port map (
          axilClk         => axilClk,                          -- [in]
          axilRst         => axilRst,                          -- [in]

--- a/base/rtl/TriggerEventManager.vhd
+++ b/base/rtl/TriggerEventManager.vhd
@@ -273,16 +273,13 @@ begin
          mAxiReadSlaves      => locAxilReadSlaves);   -- [in]
 
    -------------------------------------------------------------------------------------------------
-   -- LCLS-I timing uses EvrV2CoreTrigers to decode triggers from the EVR timing stream
-   -- LCLS-II timing uses EvrV2CoreTrigers to decode triggers from the LCLS-II timing stream
+   -- LCLS-I timing uses EvrV2CoreChannels to decode triggers from the EVR timing stream
+   -- LCLS-II timing uses EvrV2CoreChannels to decode triggers from the LCLS-II timing stream
    -------------------------------------------------------------------------------------------------
-   U_EvrV2CoreTriggers_1 : entity lcls_timing_core.EvrV2CoreTriggers
+   U_EvrV2CoreChannels_1 : entity lcls_timing_core.EvrV2CoreChannels
       generic map (
          TPD_G           => TPD_G,
          NCHANNELS_G     => NUM_DETECTORS_G,
-         NTRIGGERS_G     => NUM_DETECTORS_G,
-         TRIG_DEPTH_G    => 28,
-         TRIG_PIPE_G     => TRIGGER_PIPELINE_DEPTH_G,
          COMMON_CLK_G    => AXIL_CLK_IS_TIMING_RX_CLK_G,
          EVR_CARD_G      => false,
          AXIL_BASEADDR_G => AXIL_XBAR_CONFIG_C(AXIL_EVR_C).baseAddr)

--- a/python/l2si_core/_TriggerEventManager.py
+++ b/python/l2si_core/_TriggerEventManager.py
@@ -20,7 +20,7 @@ class TriggerEventManager(pr.Device):
             **kwargs):
         super().__init__(**kwargs)
 
-        self.add(LclsTimingCore.EvrV2CoreTriggers(
+        self.add(LclsTimingCore.EvrV2CoreChannels(
             offset  = 0x0000,
             numTrig = numDetectors,
         ))


### PR DESCRIPTION
In LCLS-I mode or LCLS-II mode with EvrV2Core triggers, replace the EvrV2CoreTriggers module with EvrV2CoreChannels.  The EvrV2CoreTriggers module provides the incorrect timestamp due to the delay of the trigger signals.