### PR TITLE
Encode trigger count into event AXIS tUserFirst

### DIFF
--- a/base/rtl/L2SiPkg.vhd
+++ b/base/rtl/L2SiPkg.vhd
@@ -88,8 +88,8 @@ package L2SiPkg is
       TDEST_BITS_C  => 1,
       TID_BITS_C    => 0,
       TKEEP_MODE_C  => TKEEP_FIXED_C,
-      TUSER_BITS_C  => 1,
-      TUSER_MODE_C  => TUSER_NONE_C);
+      TUSER_BITS_C  => 8, -- Encode the trigCnt into the tUserFirst for debugging and alignment checking
+      TUSER_MODE_C  => TUSER_FIRST_LAST_C);
 
 
 

--- a/base/rtl/TriggerEventBuffer.vhd
+++ b/base/rtl/TriggerEventBuffer.vhd
@@ -256,6 +256,7 @@ begin
             v.fifoAxisMaster.tValid               := '1';
             v.fifoAxisMaster.tdata(63 downto 0)   := (others => '0');
             v.fifoAxisMaster.tdata(127 downto 64) := evrTriggers.timeStamp;
+            v.fifoAxisMaster.tUser(7 downto 0)    := v.triggerCount(7 downto 0); -- Encode the trigCnt into the tUserFirst for debugging and alignment checking
             v.fifoAxisMaster.tLast                := '1';
 
             v.triggerData.valid    := '1';


### PR DESCRIPTION
## Description

Encodes the trigger count into the event AXIS stream's `tUserFirst` field for debugging and stream alignment checking.

### Changes
- **`base/rtl/L2SiPkg.vhd`**: Update the event AXIS stream config from `TUSER_BITS_C => 1` / `TUSER_MODE_C => TUSER_NONE_C` to `TUSER_BITS_C => 8` / `TUSER_MODE_C => TUSER_FIRST_LAST_C`.
- **`base/rtl/TriggerEventBuffer.vhd`**: Drive `tUser[7:0]` with `triggerCount[7:0]` on the first word of the event frame.

### Purpose
The trigger count carried in `tUserFirst` allows downstream logic and debug tooling to verify event stream alignment in the EventBuilderBatcher